### PR TITLE
Seesion Id 从Header中获取

### DIFF
--- a/src/Session/HttpSession.php
+++ b/src/Session/HttpSession.php
@@ -60,9 +60,14 @@ class HttpSession
         setContextValue("HttpSession", $this);
         $this->request = getDeepContextValueByClassName(Request::class);
         $this->response = getDeepContextValueByClassName(Response::class);
+
         if($this->config->getSessionUsage() == SessionConfig::USAGE_COOKIE) {
             $this->id = $this->request->getCookieParams()[$this->config->getSessionName()] ?? null;
-        }else{
+        } elseif ($this->config->getSessionUsage() == SessionConfig::USEAGE_HEADER) {
+            /** @var array $_sesionIdentify */
+            $_sesionIdentify = $this->request->getHeader(SessionConfig::HEADER_IDENTIFY);
+            $this->id = !empty($_sesionIdentify[0]) ? $_sesionIdentify[0] : null;
+        } else{
             $authorization = explode(' ',$this->request->getHeaderLine('authorization'));
             if(isset($authorization[1])){
                 $this->id = $authorization[1];

--- a/src/Session/HttpSession.php
+++ b/src/Session/HttpSession.php
@@ -60,7 +60,6 @@ class HttpSession
         setContextValue("HttpSession", $this);
         $this->request = getDeepContextValueByClassName(Request::class);
         $this->response = getDeepContextValueByClassName(Response::class);
-
         if($this->config->getSessionUsage() == SessionConfig::USAGE_COOKIE) {
             $this->id = $this->request->getCookieParams()[$this->config->getSessionName()] ?? null;
         } elseif ($this->config->getSessionUsage() == SessionConfig::USEAGE_HEADER) {
@@ -151,6 +150,7 @@ class HttpSession
     {
         unset($this->attribute[$key]);
     }
+    
     public function refresh(): void
     {
         $id = $this->getId();
@@ -162,7 +162,14 @@ class HttpSession
             $this->response->withCookie(new Cookie($this->config->getSessionName(), $this->id,
                 time() + $this->config->getTimeout(), $this->config->getPath(),
                 $this->config->getDomain(), $this->config->getSecure(), $this->config->getHttpOnly()));
-        }else{
+        } elseif ($this->config->getSessionUsage() == SessionConfig::USEAGE_HEADER) {
+            /** @var array $_sesionIdentify */
+            $_sesionIdentify = $this->request->getHeader(SessionConfig::HEADER_IDENTIFY);
+            if (!empty($_sesionIdentify[0])) {
+                $sesionIdentify = $_sesionIdentify[0];
+                $this->response->withHeader(SessionConfig::HEADER_IDENTIFY, $sesionIdentify);
+            }
+        } else{
             $this->response->withHeader('Authorization', 'Bearer ' .$this->id);
         }
         $this->setAttribute("createTime", time());

--- a/src/Session/SessionConfig.php
+++ b/src/Session/SessionConfig.php
@@ -13,8 +13,29 @@ use ESD\Core\Plugins\Config\BaseConfig;
 
 class SessionConfig extends BaseConfig
 {
+    /**
+     * Session key
+     */
     const key = "session";
+
+    /**
+     * Usage cookie
+     */
     const USAGE_COOKIE = 'cookie';
+
+    /**
+     * Usage head
+     */
+    const USEAGE_HEADER = 'header';
+
+    /**
+     * Header identify to identify session
+     */
+    const HEADER_IDENTIFY = 'sessionId';
+
+    /**
+     * Usage token
+     */
     const USAGE_TOKEN = 'token';
 
     /**
@@ -35,6 +56,13 @@ class SessionConfig extends BaseConfig
 
 
     protected $sessionUsage = SessionConfig::USAGE_COOKIE;
+
+    /**
+     * Header identity. When $sessionUsage is set to header, should set $headerIdentity
+     *
+     * @var string
+     */
+    protected $headerIdentity = SessionConfig::HEADER_IDENTIFY;
 
     /**
      * @var string


### PR DESCRIPTION
增加了Seesion Id 从Header中获取，主要用于前后端分离开发，跨域请求，又用到了SESSION的场景